### PR TITLE
Fixed image link for github-pages

### DIFF
--- a/clans/Assamite.html
+++ b/clans/Assamite.html
@@ -1,6 +1,6 @@
 <div class="container">
       <div class="col-lg-6 col-md-6 col-sm-6">
-        <img src="/clans/assamite.png" style="width: 150px; height: 90px;" />
+        <img src="clans/assamite.png" style="width: 150px; height: 90px;" />
         <h3>Clan Assamite</h3>
         The Assamites are one of the thirteen vampire clans of the Classic World of Darkness.
         Based in their hidden fortress Alamut in the Middle East, they are traditionally seen by Western Kindred


### PR DESCRIPTION
gh-pages doesn't like the leading forward slash, who knew?